### PR TITLE
Build before publish (and README.md updates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # bs-faker [![Build Status](https://travis-ci.org/Schniz/bs-faker.svg?branch=master)](https://travis-ci.org/Schniz/bs-faker) ![BuckleScript binding coverage](https://img.shields.io/badge/binding%20coverage-51%2F148-red.svg)
-
-[Faker.js](https://github.com/marak/Faker.js/) bindings for [BuckleScript](https://github.com/bloomberg/bucklescript) in [Reason](https://github.com/facebook/reason)
+> [Faker.js](https://github.com/marak/Faker.js/) bindings for [BuckleScript](https://github.com/bloomberg/bucklescript) in [Reason](https://github.com/facebook/reason)
 
 # Install
 
@@ -131,3 +130,4 @@ this will compile and execute tests with `bs-jest`
 
 Don't hesitate to open a PR with a new binding - while bumping up the amount of covered bindings in the README.
 There are tests, use them and write the most simple test you can think of to make sure that the bindings work correctly.
+[You can read more about contributing here](CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "test": "bsb -make-world && jest"
+    "test": "bsb -make-world && jest",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "BuckleScript",


### PR DESCRIPTION
* added `prepublishOnly` in `package.json` scripts, so we won't publish a package without building it
* Referred README.md to CONTRIBUTING.md