### PR TITLE
Add bindings for `date`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bs-faker [![Build Status](https://travis-ci.org/Schniz/bs-faker.svg?branch=master)](https://travis-ci.org/Schniz/bs-faker) ![BuckleScript binding coverage](https://img.shields.io/badge/binding%20coverage-114%2F148-yellowgreen.svg)
+# bs-faker [![Build Status](https://travis-ci.org/Schniz/bs-faker.svg?branch=master)](https://travis-ci.org/Schniz/bs-faker) ![BuckleScript binding coverage](https://img.shields.io/badge/binding%20coverage-119%2F148-yellowgreen.svg)
 
 > [Faker.js](https://github.com/marak/Faker.js/) bindings for [BuckleScript](https://github.com/bloomberg/bucklescript) in [Reason](https://github.com/facebook/reason)
 
@@ -94,6 +94,11 @@ let lines = BsFaker.Lorem.lines(~lineCount=3, ()); /* => string; */
 ### `BsFaker.Date`
 ```reason
 let past = BsFaker.Date.past(~years: int=?, ~refDate: Js.Date.t=?, ()); /* => Js.Date.t; */
+let future = BsFaker.Date.future(~years: int=?, ~refDate: Js.Date.t=?, ()); /* => Js.Date.t; */
+let between = BsFaker.Date.between(Js.Date.t, Js.Date.t); /* => Js.Date.t; */
+let recent = BsFaker.Date.recent(~days: int=?, ()); /* => Js.Date.t; */
+let month = BsFaker.Date.month(~opts: dateOption=?, ()); /* => string; */
+let weekday = BsFaker.Date.weekday(~opts: dateOption=?, ()); /* => string; */
 ```
 
 ### `BsFaker.Company`

--- a/__tests__/Date_test.re
+++ b/__tests__/Date_test.re
@@ -1,0 +1,98 @@
+open Jest;
+open Expect;
+open! Expect.Operators;
+
+describe("BsFaker.Date", () => {
+  describe(".past", () => {
+    test("accepts optional args", () =>
+      expect(Js.typeof(Date.past())) === "object"
+    );
+
+    test("accepts years", () =>
+      expect(Date.past(~years=1, ()) |> Js.Date.valueOf)
+      |> toBeLessThanOrEqual(Js.Date.now())
+    );
+
+    test("accepts refDate", () => {
+      let refDate =
+        Js.Date.utcWithYM(~year=2000., ~month=0., ()) |> Js.Date.fromFloat;
+      expect(Date.past(~refDate, ()) |> Js.Date.valueOf)
+      |> toBeLessThanOrEqual(refDate |> Js.Date.valueOf);
+    });
+  });
+
+  describe(".future", () => {
+    test("accepts optional args", () =>
+      expect(Js.typeof(Date.future())) === "object"
+    );
+
+    test("accepts years", () =>
+      expect(Date.future(~years=1, ()) |> Js.Date.valueOf)
+      |> toBeGreaterThanOrEqual(Js.Date.now())
+    );
+
+    test("accepts refDate", () => {
+      let refDate =
+        Js.Date.utcWithYM(~year=2000., ~month=0., ()) |> Js.Date.fromFloat;
+      expect(Date.future(~refDate, ()) |> Js.Date.valueOf)
+      |> toBeGreaterThanOrEqual(refDate |> Js.Date.valueOf);
+    });
+  });
+
+  describe(".between", () => {
+    test("returns date greater than or equal to `from` date", () => {
+      let from =
+        Js.Date.utcWithYM(~year=2000., ~month=0., ()) |> Js.Date.fromFloat;
+      let to_ =
+        Js.Date.utcWithYM(~year=2000., ~month=1., ()) |> Js.Date.fromFloat;
+      expect(Date.between(from, to_) |> Js.Date.valueOf)
+      |> toBeGreaterThanOrEqual(from |> Js.Date.valueOf);
+    });
+
+    test("returns date less than or equal to `to_` date", () => {
+      let from =
+        Js.Date.utcWithYM(~year=2000., ~month=0., ()) |> Js.Date.fromFloat;
+      let to_ =
+        Js.Date.utcWithYM(~year=2000., ~month=1., ()) |> Js.Date.fromFloat;
+      expect(Date.between(from, to_) |> Js.Date.valueOf)
+      |> toBeLessThanOrEqual(to_ |> Js.Date.valueOf);
+    });
+  });
+
+  describe(".recent", () => {
+    test("accepts optional args", () =>
+      expect(Js.typeof(Date.recent())) === "object"
+    );
+
+    test("accepts days", () =>
+      expect(Date.recent(~days=1, ()) |> Js.Date.valueOf)
+      |> toBeLessThanOrEqual(Js.Date.now())
+    );
+  });
+
+  describe(".month", () => {
+    test("accepts optional args", () =>
+      expect(Js.typeof(Date.month())) === "string"
+    );
+
+    test("accepts opts", () =>
+      expect(
+        Js.typeof(Date.month(~opts={"abbr": true, "context": false}, ())),
+      )
+      === "string"
+    );
+  });
+
+  describe(".weekday", () => {
+    test("accepts optional args", () =>
+      expect(Js.typeof(Date.weekday())) === "string"
+    );
+
+    test("accepts opts", () =>
+      expect(
+        Js.typeof(Date.weekday(~opts={"abbr": true, "context": false}, ())),
+      )
+      === "string"
+    );
+  });
+});

--- a/src/Date.re
+++ b/src/Date.re
@@ -1,7 +1,26 @@
 let nullable = Faker.nullable;
 
+type dateOption = {
+  .
+  "abbr": bool,
+  "context": bool,
+};
+
 [@bs.deriving abstract]
-type t = {past: (Js.Nullable.t(int), Js.Nullable.t(Js.Date.t)) => Js.Date.t};
+type t = {
+  past: (Js.Nullable.t(int), Js.Nullable.t(Js.Date.t)) => Js.Date.t,
+  future: (Js.Nullable.t(int), Js.Nullable.t(Js.Date.t)) => Js.Date.t,
+  between: (Js.Date.t, Js.Date.t) => Js.Date.t,
+  recent: Js.Nullable.t(int) => Js.Date.t,
+  month: Js.Nullable.t(dateOption) => string,
+  weekday: Js.Nullable.t(dateOption) => string,
+};
 [@bs.module "faker"] external fakers : t = "date";
 let past = (~years=?, ~refDate=?, ()) =>
   past(fakers, nullable(years), nullable(refDate));
+let future = (~years=?, ~refDate=?, ()) =>
+  future(fakers, nullable(years), nullable(refDate));
+let between = (from, to_) => between(fakers, from, to_);
+let recent = (~days=?, ()) => recent(fakers, nullable(days));
+let month = (~opts=?, ()) => month(fakers, nullable(opts));
+let weekday = (~opts=?, ()) => weekday(fakers, nullable(opts));

--- a/src/Date.rei
+++ b/src/Date.rei
@@ -1,1 +1,11 @@
+type dateOption = {
+  .
+  "abbr": bool,
+  "context": bool,
+};
 let past: (~years: int=?, ~refDate: Js.Date.t=?, unit) => Js.Date.t;
+let future: (~years: int=?, ~refDate: Js.Date.t=?, unit) => Js.Date.t;
+let between: (Js.Date.t, Js.Date.t) => Js.Date.t;
+let recent: (~days: int=?, unit) => Js.Date.t;
+let month: (~opts: dateOption=?, unit) => string;
+let weekday: (~opts: dateOption=?, unit) => string;


### PR DESCRIPTION
This PR closes https://github.com/Schniz/bs-faker/issues/5

Now the latest `Faker.js` has no API called `soon` (I suppose), so I implemented APIs below:

```
date
    past
    future  <- Added
    between <- Added
    recent  <- Added
    soon
    month   <- Added
    weekday <- Added
```